### PR TITLE
fix dependency pip install with git, was missing -e (test still erring out locally and on travis, but closer)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - "2.7"
   - "2.6"
 install:
-  - pip install --upgrade -r requirements.txt -r test-requirements.txt . --use-mirrors
+  - pip install -r requirements.txt -r test-requirements.txt . --use-mirrors
 before_script:
   - "flake8 --show-source --builtins=_ wafflehaus.neutron"
 script:
-  - nosetests --with-coverage --cover-package=quark --cover-erase --cover-html --cover-html-dir=.cover-report --cover-min-percentage=10
+  - nosetests --with-coverage --cover-package=wafflehaus.neutron --cover-erase --cover-html --cover-html-dir=.coverage-report --cover-min-percentage=10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dnspython
 webob
-git+https://github.com/openstack/neutron.git#egg=neutron
-git+https://github.com/roaet/wafflehaus.git@development#egg=wafflehaus
+-e git+https://github.com/openstack/neutron.git#egg=neutron
+-e git+https://github.com/roaet/wafflehaus.git@development#egg=wafflehaus

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,11 @@ commands =
 setenv = VIRTUAL_ENV={envdir}
          NOSE_WITH_COVERAGE=1
          NOSE_COVER_HTML=1
-         NOSE_COVER_HTML_DIR=.cover-report
+         NOSE_COVER_HTML_DIR=.coverage-report
          NOSE_COVER_MIN_PERCENTAGE=90
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = nosetests --cover-package=wafflehaus_neutron --cover-erase {posargs}
+commands = nosetests --cover-package=wafflehaus.neutron --cover-erase {posargs}
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
- This will have wafflehaus and neutron dependencies install from git correctly:
  
  was installing wafflehaus like:
  
  `wafflehaus==0.2dev` 
  (which is master branch)
  
  and now will be:
  
  `-e git+https://github.com/roaet/wafflehaus.git@362a751d3733151f7a52404939d4bc70810dbbee#egg=
  wafflehaus-origin/development` 
  (which is the development branch)
- removed --upgrade from .travis.yml, did not help
- changed the coverage report folder to match what was in .gitignore
