### PR TITLE
Body 'true' causes 500s

### DIFF
--- a/tests/test_last_ip_check.py
+++ b/tests/test_last_ip_check.py
@@ -68,6 +68,7 @@ class TestLastIpCheck(tests.TestCase):
         self.bad_resource = '{"derp": {"fixed_ips":[{"derp": "derp"}]}}'
         self.bad_no_fixed = '{"port": {"derply":[{"derp": "derp"}]}}'
         self.empty_fixed_ips = '{"port": {"fixed_ips":[]}}'
+        self.true_body = 'true'
 
     def test_create_ip_check(self):
         checker = last_ip_check.filter_factory(self.global_conf)(self.app)
@@ -115,6 +116,11 @@ class TestLastIpCheck(tests.TestCase):
     def test_put_only_v6(self):
         resp = self.checker(webob.Request.blank('/ports/1234', method='PUT',
                                                 body=self.good_only_v6))
+        self.assertEqual(self.app, resp)
+
+    def test_put_body_true(self):
+        resp = self.checker(webob.Request.blank('/ports/1234', method='PUT',
+                                                body=self.true_body))
         self.assertEqual(self.app, resp)
 
     def test_runtime_override(self):

--- a/wafflehaus/neutron/last_ip_check/last_ip_check.py
+++ b/wafflehaus/neutron/last_ip_check/last_ip_check.py
@@ -48,7 +48,10 @@ class LastIpCheck(WafflehausBase):
             body_json = json.loads(body)
         except ValueError:
             return webob.exc.HTTPBadRequest
-        port_info = body_json.get('port')
+        try:
+            port_info = body_json.get('port')
+        except AttributeError:
+            return False
         if port_info is None:
             return False
         fixed_ips = port_info.get('fixed_ips')


### PR DESCRIPTION
If a PUT contained a body of 'true', it evaluates to bool True.
This causes a trace in _should_run when calling body_json.get().

RM#11690