### PR TITLE
Set context.advsvc based on what the policy says it should be

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,6 +12,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
+import mock
+
 from wafflehaus import tests
 
 
@@ -20,3 +23,5 @@ class TestBase(tests.TestCase):
 
     def setUp(self):
         super(TestBase, self).setUp()
+        # Stop all patchers so that we get a fresh patcher every test
+        self.addCleanup(mock.patch.stopall)


### PR DESCRIPTION
JIRA:NCP-1819

This also had to up date the tests to use an up-to-date neutron.  I put that change in a separate commit to keep it clean.  If it is preferred to make separate PRs or even squash these into one, let me know.